### PR TITLE
Add FileCacheControl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@statenspensjonskasse/moxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statenspensjonskasse/moxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Mock all the things with Moxy.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -152,6 +152,25 @@ app.use(moxy({
 app.listen(1337);
 ```
 
+## Using File Cache Control
+
+How to use Moxy with a static file cache.
+`fileCacheControl` takes one argument, the relative file to a JSON file containing the cache.
+When the application with Moxy starts
+
+
+```javascript
+const express = require('express');
+const { moxy, fileCacheControl } = require('@statenspensjonskasse/moxy');
+const app = express();
+
+app.use(moxy({
+  cacheControl: fileCacheControl('/relative/file/path/to/run/cache.json'),
+));
+
+app.listen(1337);
+```
+
 ## Using Your Own Cache Control
 
 ```javascript

--- a/src/cacheControl/FileCacheControl.ts
+++ b/src/cacheControl/FileCacheControl.ts
@@ -1,0 +1,66 @@
+import { CacheControl } from '../types';
+import fs from 'fs';
+import path from 'path';
+
+export const fileCacheControl = (
+  relativeFileName = 'cache.json'
+): CacheControl => {
+  let cache: any = {};
+  const cacheFile = path.join(process.cwd(), relativeFileName);
+
+  fs.exists(cacheFile, (exists) => {
+    if (!exists) {
+      fs.writeFile(cacheFile, JSON.stringify({}), (err) => {
+        if (err) throw err;
+      });
+    } else {
+      fs.readFile(cacheFile, 'utf8', (err, data) => {
+        if (err) throw err;
+        cache = JSON.parse(data);
+      });
+    }
+  });
+
+  const record = (key: string, value: any): Promise<any> => {
+    return new Promise((resolve, reject) => {
+      const requests = cache[key] || [];
+
+      if (requests.length === 0) {
+        cache[key] = [value];
+      } else {
+        for (let i = 0; i < requests.length; i++) {
+          if (requests[i].method === value.method) {
+            requests[i] = value;
+          }
+        }
+      }
+
+      return fs.writeFile(cacheFile, JSON.stringify(cache), (err) => {
+        if (err) return reject('Could not write to file');
+        return resolve(value);
+      });
+    });
+  };
+
+  const find = (key: string, method: string): Promise<any> => {
+    return new Promise((resolve, reject) => {
+      const requests: any = cache[key];
+      if (requests === undefined || requests.length === 0) {
+        return reject('No cache for request');
+      }
+
+      for (const request of requests) {
+        if (request.method === method) {
+          return resolve(request);
+        }
+      }
+
+      return reject('Nothing found in list');
+    });
+  };
+
+  return {
+    record,
+    find,
+  };
+};

--- a/src/cacheControl/FileCacheControl.ts
+++ b/src/cacheControl/FileCacheControl.ts
@@ -8,13 +8,13 @@ export const fileCacheControl = (
   let cache: any = {};
   const cacheFile = path.join(process.cwd(), relativeFileName);
 
-  fs.exists(cacheFile, (exists) => {
+  fs.exists(cacheFile, (exists: boolean) => {
     if (!exists) {
-      fs.writeFile(cacheFile, JSON.stringify({}), (err) => {
+      fs.writeFile(cacheFile, JSON.stringify({}), (err: Error) => {
         if (err) throw err;
       });
     } else {
-      fs.readFile(cacheFile, 'utf8', (err, data) => {
+      fs.readFile(cacheFile, 'utf8', (err: Error, data: any) => {
         if (err) throw err;
         cache = JSON.parse(data);
       });
@@ -35,7 +35,7 @@ export const fileCacheControl = (
         }
       }
 
-      return fs.writeFile(cacheFile, JSON.stringify(cache), (err) => {
+      return fs.writeFile(cacheFile, JSON.stringify(cache), (err: Error) => {
         if (err) return reject('Could not write to file');
         return resolve(value);
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { default as moxy } from './moxy';
 export { moxyRouter } from './moxyRouter';
 export { memoryCacheControl } from './cacheControl/MemoryCacheControl';
+export { fileCacheControl } from './cacheControl/FileCacheControl';
 export { mongoDbCacheControl } from './cacheControl/MongoDbCacheControl';
 export { MoxyMode } from './types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "sourceMap": true,
     "noImplicitAny": true,
     "removeComments": true,
+    "esModuleInterop": true,
     "module": "commonjs",
     "lib": ["dom", "es5", "es6"],
     "listEmittedFiles": true,


### PR DESCRIPTION
File cache enables storage of moxy cache to a given file relative to run path (default `cache.json`).